### PR TITLE
Add voice commands around power on/off

### DIFF
--- a/Alexa Skill Voice Commands & Intents/SampleUtterances.txt
+++ b/Alexa Skill Voice Commands & Intents/SampleUtterances.txt
@@ -127,6 +127,9 @@ Select yes
 Power turn off
 Power fuck off
 Power goodbye
+Power turn on
+Power power on
+Power power off
 
 Back go back
 Back back up


### PR DESCRIPTION
FYI the power command will turn on the TCL Roku TV (only tested with ethernet not wifi as that is my current setup)
* Add voice commands to "power off",  "power on", and "turn on" roku
* Keep in mind on a device such as TCL Roku TV the power command, regardless of what phrased used, will toggle the power
  * If it's on it will turn off
  * If it's off it will turn on